### PR TITLE
add a flag to disable starting the browser when using the console proxy

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,6 +18,7 @@ import (
 var (
 	runArgs struct {
 		consoleProxy bool
+		noBrowser    bool
 	}
 
 	// runCmd represents the run command
@@ -32,6 +33,7 @@ var (
 func init() {
 	serviceCmd.AddCommand(runCmd)
 	runCmd.Flags().BoolVarP(&runArgs.consoleProxy, "console-proxy", "p", false, "Start the vega console proxy and open the console in the default browser")
+	runCmd.Flags().BoolVarP(&runArgs.noBrowser, "no-browser", "n", false, "Do not open the default browser if the console proxy is stated")
 }
 
 func runServiceRun(cmd *cobra.Command, args []string) error {
@@ -72,11 +74,13 @@ func runServiceRun(cmd *cobra.Command, args []string) error {
 			}
 		}()
 
-		// then we open the console for the user straight at the right runServiceRun
-		err := open.Run(cproxy.GetBrowserURL())
-		if err != nil {
-			log.Error("unable to open the console in the default browser",
-				zap.Error(err))
+		if !runArgs.noBrowser {
+			// then we open the console for the user straight at the right runServiceRun
+			err := open.Run(cproxy.GetBrowserURL())
+			if err != nil {
+				log.Error("unable to open the console in the default browser",
+					zap.Error(err))
+			}
 		}
 	}
 


### PR DESCRIPTION
As per @barnabee's request, provide the `-n` or `--no-browser` option when running the proxy to prevent the browser from being opened automatically