### PR TITLE
refactor to more idiomatic golang

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"code.vegaprotocol.io/go-wallet/cmd/printer"
 	"code.vegaprotocol.io/go-wallet/version"
@@ -17,6 +19,9 @@ import (
 )
 
 var (
+	// versionWaitTimeout the timeout of acquiring the latest version from github
+	versionWaitTimeout = 30 * time.Second
+
 	rootArgs struct {
 		output         string
 		home           string
@@ -65,7 +70,9 @@ func checkVersion() error {
 		if version.IsUnreleased(version.Version) {
 			p.CrossMark().DangerText("You are running an unreleased version of the Vega wallet. Use it at your own risk!").NJump(2)
 		} else {
-			v, err := version.Check(version.Version)
+			ctx, cancel := context.WithTimeout(context.Background(), versionWaitTimeout)
+			defer cancel()
+			v, err := version.Check(ctx, version.Version)
 			if err != nil {
 				return fmt.Errorf("could not check Vega wallet version updates: %w", err)
 			}

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -33,8 +34,8 @@ func IsUnreleased(currentVersion string) bool {
 
 // Check returns a newer version, or an error or nil for both
 // if no error happened, and no updates are needed
-func Check(currentVersion string) (*semver.Version, error) {
-	req, err := http.NewRequest("GET", ReleaseAPI, nil)
+func Check(ctx context.Context, currentVersion string) (*semver.Version, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ReleaseAPI, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I'm trying (WIP) to refactor go-wallet into a more idiomatic go and make it more compatible with Linters.

references:
- [50 shades of golang](http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/index.html)
- [effective golang](https://golang.org/doc/effective_go)