### PR TITLE
Run system-tests in CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('vega-shared-library') _
+
 /* properties of scmVars (example):
     - GIT_BRANCH:PR-40
     - GIT_COMMIT:05a1c6fbe7d1ff87cfc40a011a63db574edad7e6


### PR DESCRIPTION
Closes #278. 
Note the config:
- `systemTests ignoreFailure: false` - so if `system-tests` fails, then the `go-wallet` pipeline will be marked as failed
- `systemTestsLNL ignoreFailure: true` - all LNL pipeline failures won't affect the `go-wallet` pipeline status