### PR TITLE
CI: use correct commit hash to start downstream jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
                 cleanWs()
                 sh 'printenv'
                 echo "${params}"
+                echo "isPRBuild=${isPRBuild()}"
             }
         }
 
@@ -201,7 +202,7 @@ pipeline {
                 stage('System Tests') {
                     steps {
                         script {
-                            systemTests ignoreFailure: false,
+                            systemTests ignoreFailure: !isPRBuild(),
                                 vegaCore: params.VEGA_CORE_BRANCH,
                                 dataNode: params.DATA_NODE_BRANCH,
                                 goWallet: commitHash,


### PR DESCRIPTION
and use the slack helper method from the shared library
