### PR TITLE
Don't use unicode glyphs on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### 🐛 Fixes
 - [440](https://github.com/vegaprotocol/vegawallet/pull/440) - Fix confirmation prompt on windows
-
+- [449](https://github.com/vegaprotocol/vegawallet/pull/449) - Don't use unicode glyphs on windows
 
 ## 0.11.0
 

--- a/cmd/printer/interactive.go
+++ b/cmd/printer/interactive.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"fmt"
 	"io"
+	"runtime"
 
 	"github.com/muesli/termenv"
 )
@@ -16,9 +17,7 @@ type InteractivePrinter struct {
 	arrow     termenv.Style
 }
 
-func NewInteractivePrinter(w io.Writer) *InteractivePrinter {
-	enableLegacyWindowsANSI()
-	profile := termenv.EnvColorProfile()
+func fancyPrinter(w io.Writer, profile termenv.Profile) *InteractivePrinter {
 	return &InteractivePrinter{
 		writer:    w,
 		profile:   profile,
@@ -27,6 +26,26 @@ func NewInteractivePrinter(w io.Writer) *InteractivePrinter {
 		crossMark: termenv.String("✗ ").Foreground(profile.Color("1")).String(),
 		arrow:     termenv.String("➜ ").Foreground(profile.Color("2")),
 	}
+}
+
+func ansiPrinter(w io.Writer, profile termenv.Profile) *InteractivePrinter {
+	return &InteractivePrinter{
+		writer:    w,
+		profile:   profile,
+		checkMark: termenv.String("* ").Foreground(profile.Color("2")).String(),
+		bangMark:  termenv.String("! ").Foreground(profile.Color("1")).String(),
+		crossMark: termenv.String("x ").Foreground(profile.Color("1")).String(),
+		arrow:     termenv.String("> ").Foreground(profile.Color("2")),
+	}
+}
+
+func NewInteractivePrinter(w io.Writer) *InteractivePrinter {
+	enableLegacyWindowsANSI()
+	profile := termenv.EnvColorProfile()
+	if runtime.GOOS == "windows" {
+		return ansiPrinter(w, profile)
+	}
+	return fancyPrinter(w, profile)
 }
 
 func (p *InteractivePrinter) GreenArrow() *InteractivePrinter {


### PR DESCRIPTION
Closes #436 

Stick to ascii characters on windows, because the default font used in cmd.exe doesn't render them.