### PR TITLE
docs: replace link for providing feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [521](https://github.com/vegaprotocol/vegawallet/pull/521) - Update `protos` repository to get last validation updates on commands
 - [523](https://github.com/vegaprotocol/vegawallet/pull/521) - Add link in `README` to direct people to desktop wallet app
 - [529](https://github.com/vegaprotocol/vegawallet/pull/529) - Ensure log files can be created on Windows.
-
+- [536](https://github.com/vegaprotocol/vegawallet/pull/536) - Docs: replace link for providing feedback
 
 ## 0.13.2
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Using the API is documented [here](service/README.md).
 
 ## Support
 
-#### [Nolt][nolt]
+#### [Feedback][feedback]
 Raise issues and see what others have raised.
 
 #### [Discord][discord]
@@ -118,6 +118,6 @@ Read more at [https://vega.xyz][vega-website].
 [vega-documentation-website-create-wallet]: https://docs.vega.xyz/docs/tools/vega-wallet/CLI-wallet/create-wallet
 [vega-wallet-documentation-website]: https://docs.vega.xyz/docs/tools/vega-wallet/
 [vega-wallet-desktop-getting-started]: https://docs.vega.xyz/docs/tools/vega-wallet/desktop-app/latest/getting-started
-[nolt]: https://vega-testnet.nolt.io/
+[feedback]: https://github.com/vegaprotocol/feedback/discussions/
 [discord]: https://vega.xyz/discord
 [github-releases]: https://github.com/vegaprotocol/vegawallet/releases


### PR DESCRIPTION
Closes #535 

Replaces the link for feedback with the new feedback board