### PR TITLE
Release version 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 ### 🐛 Fixes
 - [](https://github.com/vegaprotocol/vegawallet/pull/) -
 
+## 0.16.1
+
+### 🐛 Fixes
+- Fix hardcoded version to match tag and build binaries
+
 ## 0.16.0
 
 ### 🐛 Fixes

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ const (
 	ReleasesAPI        = "https://api.github.com/repos/vegaprotocol/vegawallet/releases"
 	ReleasesURL        = "https://github.com/vegaprotocol/vegawallet/releases"
 	defaultVersionHash = "unknown"
-	defaultVersion     = "v0.16"
+	defaultVersion     = "v0.16.1"
 )
 
 var (


### PR DESCRIPTION
Release v0.16.1, v0.16.0 had bad hardcoded version, binaries would not build.